### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/mostafaelbayyar/a5f720fd-cdf7-403f-b7aa-1db2af2db75f/a38ed174-088e-4aef-9f18-27b30da7be9f/_apis/work/boardbadge/7c16a641-37a7-4c4f-a3c2-75732cc148de)](https://dev.azure.com/mostafaelbayyar/a5f720fd-cdf7-403f-b7aa-1db2af2db75f/_boards/board/t/a38ed174-088e-4aef-9f18-27b30da7be9f/Microsoft.RequirementCategory)
 
 
 ```markdown


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/mostafaelbayyar/a5f720fd-cdf7-403f-b7aa-1db2af2db75f/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.